### PR TITLE
fix: drop docs/ in gitignore (R-related) for template compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,6 @@ vignettes/*.pdf
 # R Environment Variables
 .Renviron
 
-# pkgdown site
-docs/
-
 # translation temp files
 po/*~
 


### PR DESCRIPTION
Removes the entry "docs/" from gitignore to establish compatibility with the workflow template for Snakemake (besides the obvious thing that "docs/" is a pretty common abbreviation for "documentation" in repositories).