### PR TITLE
Update year, bump version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Core Unit Bioinformatics, Medical Faculty, HHU
+Copyright (c) 2022-2023 Core Unit Bioinformatics, Medical Faculty, HHU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [cubi.metadata]
 pid = "undefined"
-version = "1.2.1"
+version = "1.3.1"
 
 [cubi.metadata.naming.workflow.system]
 smk="snakemake"


### PR DESCRIPTION
- update year in license to range 2022-2023
- bump version to v1.3.1