### PR TITLE
Update to v1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [cubi.metadata]
 pid = "undefined"
-version = "1.3.2"
+version = "1.4.0"
 
 [cubi.metadata.naming.workflow.system]
 smk="snakemake"

--- a/tomls/cubi/project/pyproject.toml
+++ b/tomls/cubi/project/pyproject.toml
@@ -20,8 +20,3 @@ version = "version_b"
 pid = "pid_c"
 name = "c"
 version = "version_c"
-
-[cubi.project.workflow.upstream]
-pid = "undefined"  
-name = "undefined"
-version = "prototype"

--- a/tomls/cubi/project/pyproject.toml
+++ b/tomls/cubi/project/pyproject.toml
@@ -4,7 +4,7 @@ type = "type"
 name = "undefined"
 start_date = 2000-01-01
 end_data = 2099-12-31
-version = ""
+version = "optional"
 
 [[cubi.project.workflow]]
 pid = "pid_a"

--- a/tomls/cubi/project/pyproject.toml
+++ b/tomls/cubi/project/pyproject.toml
@@ -4,6 +4,7 @@ type = "type"
 name = "undefined"
 start_date = 2000-01-01
 end_data = 2099-12-31
+version = ""
 
 [[cubi.project.workflow]]
 pid = "pid_a"

--- a/tomls/cubi/tools/pyproject.toml
+++ b/tomls/cubi/tools/pyproject.toml
@@ -1,0 +1,13 @@
+[cubi.tools]
+pid="https://github.com/core-unit-bioinformatics/cubi-tools"
+# the PID is hard-coded because there can only
+# be one CUBI-tools repository
+version="pkg_version"
+
+[[cubi.tools.script]]
+name="script_a"
+version="version_a"
+
+[[cubi.tools.script]]
+name="script_b"
+version="version_b"


### PR DESCRIPTION
- add optional version for project repositories
  - example: keep track of different runs/configs in project
- add pyproject template for cubi-tools repository 