### PR TITLE
Early 2024 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ wd/
 backup/
 .backup/
 *.bak
+
+# Ignore all paths containing the keyword *cache*
+*cache*

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 Core Unit Bioinformatics, Medical Faculty, HHU
+Copyright (c) 2022-2024 Core Unit Bioinformatics, Medical Faculty, HHU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [cubi.metadata]
 pid = "undefined"
-version = "1.4.0"
+version = "1.5.0"
 
 [cubi.metadata.naming.workflow.system]
 smk="snakemake"


### PR DESCRIPTION
- update year in license file
- add generic `*cache*` entry to gitignore matching all file names containing `cache` 
- bump version to v1.5.0